### PR TITLE
Use SQLAlchemy to support multiple protocols

### DIFF
--- a/lua/dbview/api.py
+++ b/lua/dbview/api.py
@@ -2,6 +2,8 @@ import json
 import sqlite3
 import sys
 
+from sqlalchemy import create_engine, text
+
 ALIASES = {
     ".tables": "SELECT type, name FROM sqlite_master WHERE type='table'",
     ".schema": "SELECT sql FROM sqlite_master",
@@ -11,38 +13,40 @@ ALIASES = {
 if __name__ == "__main__":
     if sys.argv[1] == "query":
         file = sys.argv[2]
-        query = sys.argv[3].strip()
+        query = " ".join(sys.argv[3:]).strip()
         query = ALIASES.get(query.lower(), query)
+        engine = create_engine(file if "://" in file else f"sqlite:///{file}")
         try:
-            with sqlite3.connect(file) as con:
-                cur = con.cursor()
-                res = cur.execute(query)
-                all_ = res.fetchall()
+            with engine.connect() as con:
+                res = con.execute(text(query))
+                all_ = [[str(j) for j in i] for i in res.fetchall()]
                 one = all_[0] if all_ else None
                 d = {
                     "one": one,
                     "all": all_,
-                    "success": bool(cur.rowcount),
+                    "success": res.rowcount > 0,
                     "query": query,
                 }
                 j = json.dumps(d, indent=4)
                 j = j.replace("\\n", "%n").replace('\\"', "'").replace("\\t", "    ")
                 print(j)
                 con.commit()
-                cur.close()
+                con.close()
         except Exception as e:
             d = {
                 "one": None,
                 "all": (),
                 "success": False,
                 "error": str(e),
-                "query": query,
+                "query": str(query),
             }
             j = json.dumps(d, indent=4)
             j = j.replace("\\n", "\n")
             print(j)
     elif sys.argv[1] == "new":
         file = sys.argv[2]
+        if "://" in file and not "sqlite" in file:
+            file = f"sqlite:///{file.split('://')[1]}"
         con = sqlite3.connect(file)
         con.commit()
         con.close()

--- a/lua/dbview/init.lua
+++ b/lua/dbview/init.lua
@@ -1,11 +1,13 @@
 local M = {}
 
+local pythonExecutable = "/home/script/Workspaces/Projects/nvim-dbview/.venv/bin/python"
+
 M.rootpath = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h")
 M.apipath = M.rootpath .. "/api.py"
 
 -- Helper: Run Python script to query DB
 function M.query_db(db, query)
-	local json = vim.fn.system({ "python", M.apipath, "query", db, query })
+	local json = vim.fn.system({ pythonExecutable, M.apipath, "query", db, query })
 	return vim.fn.json_decode(json)
 end
 
@@ -112,7 +114,7 @@ end
 
 -- Create new DB files from command or lua
 function M.new(db)
-	vim.fn.system({ "python", M.apipath, "new", db })
+	vim.fn.system({ pythonExecutable, M.apipath, "new", db })
 end
 
 -- Set up user commands and autocommands


### PR DESCRIPTION
I replaced the sqlite3 driver with SQLAlchemy (partially) in an attempt to automatically find out which driver to use from the URI's protocol.

SQLAlchemy and the appropriate driver, so for example, to use postgres I need to pip install both sqlalchemy and psycopg2.

Lmk if you need anything.
